### PR TITLE
Fix error in HTTP Method of Create Session

### DIFF
--- a/Picobrew Z API.md
+++ b/Picobrew Z API.md
@@ -492,7 +492,8 @@ Example:
 
 ##### Request
 
-`PUT https://www.picobrew.com/Vendors/input.cshtml?type=ZSession&token=<token>&id=<session_id> HTTP/1.1`
+TODO ... is the begin a `POST` and the complete a `PUT`, but definitely create/begin is a `POST` from today's session on my device
+`POST https://www.picobrew.com/Vendors/input.cshtml?type=ZSession&token=<token>&id=<session_id> HTTP/1.1`
 
 When beginning a new program session, the session_id is not included in the query string.  This value is present when completing a program session and is the only observed request difference between a begin session and complete session request.
 


### PR DESCRIPTION
Today I had a test brew session with a local server implementation. The brew session failed to report stats during the session cause the endpoint was implemented as a `PUT` as per this documentation, but in my prior captures and this brew session the request to start a new logging session was ` POST` vs a `PUT`.

- [x] resolve what the "complete" session request is

